### PR TITLE
Starting perspective

### DIFF
--- a/src/TravellingSailorProblem.jl
+++ b/src/TravellingSailorProblem.jl
@@ -2,7 +2,7 @@ module TravellingSailorProblem
 
 using SpeedyWeather, Printf
 
-include("names_cities.jl")
+include("names_places.jl")
 include("destination.jl")
 include("evaluation.jl")
 include("visualisation.jl")

--- a/src/destination.jl
+++ b/src/destination.jl
@@ -79,9 +79,7 @@ function Base.show(io::IO, ds::NTuple{N, <:Destination}) where N
 	for d in ds[1:end-1]
 		println(io, shortstring(d))
 	end
-	for d in ds[end:end]
-		print(io, shortstring(d))
-	end
+	print(io, shortstring(ds[end]))
 end
 
 const NCHILDREN = 10

--- a/src/names_places.jl
+++ b/src/names_places.jl
@@ -8,13 +8,13 @@ const MAX_NAME_LENGTH = maximum(length.(string.(NAMES)))
 
 const PLACES = [
   (15.6, 78.2),       # Longyearbyen, Svalbard
-  (140.7, 69.3),      # Magadan, Russia
+  (158.7, 53.0),      # Kamchatka, Russia
   (-51.7, 64.2),      # Nuuk, Greenland
-  (76.9, 43.2),       # Almaty, Kazakhstan
+  (106.9, 47.9),      # Ulaanbaatar, Mongolia
   (-97.1, 49.9),      # Winnipeg, Canada
   (-96.7, 17.1),      # Oaxaca, Mexico
   (-7.6, 33.6),       # Casablanca, Morocco
-  (106.8, 10.8),      # Ho Chi Minh City, Vietnam
+  (106.8, 10.8),      # Ho Chi Minh City, Vietnamxw
   (-74.1, 4.7),       # Bogotá, Colombia
   (-157.8, 21.3),     # Honolulu, Hawaii
   (15.3, 4.4),        # Bangui, Central African Republic
@@ -22,7 +22,7 @@ const PLACES = [
   (-47.9, -15.8),     # Brasília, Brazil
   (151.2, -33.9),     # Sydney, Australia
   (-5.9, -15.9),      # Saint Helena
-  (115.0, -8.7),      # Bali, Indonesia (adjusted for better spacing)
+  (115.0, -8.7),      # Bali, Indonesia
   (-70.7, -53.2),     # Punta Arenas, Chile
   (85.3, 27.7),       # Kathmandu, Nepal
   (-1.3, 51.8),       # Oxford, UK

--- a/src/visualisation.jl
+++ b/src/visualisation.jl
@@ -33,12 +33,15 @@ function SpeedyWeather.globe(
     background::Bool = true,
     coastlines::Bool = true,
     interactive::Bool = true,
+    legend::Bool = true,
     altitude_tracks = 200_000,
     altitude_destinations = 200_000,
-    perspective = (30, 45),
+    perspective = (0, 0),
     altitude = 2e7,
-    size=(800, 800),
+    size = (800, 800),
 ) where N
+
+    perspective = perspective isa Destination ? perspective.lonlat : perspective
 
     Makie.set_theme!(Attributes(; palette = (; color = Makie.to_colormap(:tab20), patchcolor = Makie.to_colormap(:tab20))))
 
@@ -55,7 +58,7 @@ function SpeedyWeather.globe(
             alt = altitude,
         ))
 
-        # Now, we update the camera to look at Pittsburgh.
+        # Now, we update the camera
         cc = cameracontrols(ax.scene)
         cc.eyeposition[] = ecef
         cc.lookat[] = Vec3d(0,0,0)
@@ -119,7 +122,7 @@ function SpeedyWeather.globe(
     scatter!(ax, 0, 0, -1e6; marker=:hexagon, color=0, colorrange=(0, 1), markersize=16, label="reached")
     scatter!(ax, 0, 0, -1e6; marker=:hexagon, color=1, colorrange=(0, 1), markersize=16, label="missed")
 
-    axislegend(ax, position=:lb)
+    legend && axislegend(ax, position=:lb)
 
     fig
 end 


### PR DESCRIPTION
fixes #18  Now starting by default at 0,0

<img width="801" height="828" alt="image" src="https://github.com/user-attachments/assets/ee522eaa-11b5-4b55-9f85-e9259acc0122" />

or with `globe(children, perspective=children[1])` focused on that child

<img width="801" height="828" alt="image" src="https://github.com/user-attachments/assets/a2bf221c-360e-4520-ac3b-a4aadfe458f6" />

but `altitude` doesn't work yet