### PR TITLE
remove GLMakie import

### DIFF
--- a/submissions/luke_simple.jl
+++ b/submissions/luke_simple.jl
@@ -20,7 +20,7 @@ departures = [
             i == 23 ? (lon - 5, lat + 1) :      # Walter
             (lon - 5, lat)                      # default (all others)
 
-        T(newlon, newlat)
+        (newlon, newlat)
     end
     for i in eachindex(children)
 ]


### PR DESCRIPTION
@lukemccarvill the `using GLMakie` causes problems as we want to try to use WGLMakie (WebGL backend instead of OpenGL) to have the interactivity also on the web, I've removed this and removed the unnecessary SpeedyWeather setup/run/evaluate code as this will be done automatically by GitHub actions