### PR TITLE
Add Wind Rider submission (78101 points, 5/5 reached)

### DIFF
--- a/submissions/wind_rider.jl
+++ b/submissions/wind_rider.jl
@@ -1,0 +1,18 @@
+name = "Wind Rider"
+description = "Optimized westerly trajectories"
+
+nchildren = 5       # [1, 26]
+layer = 6           # [1, 8], 1 is top layer, 8 is surface layer
+
+# Optimized departure locations (lon, lat) in degrees
+# Strategy: Use westerlies at layer 6 with carefully tuned offsets
+# Ana benefits from a long circumnavigation trajectory at offset 6
+# Elif needs a larger offset of 50 degrees west to reach Manila
+
+departures = [
+    (-103.1,  49.9),  # Ana (Winnipeg) - 6 deg west offset
+    ( 109.0,  -8.7),  # Babu (Bali) - 6 deg west offset
+    (  67.5,  -4.6),  # Carla (Seychelles) - 6 deg west offset
+    ( -57.7,  64.2),  # Diego (Nuuk) - 6 deg west offset
+    (  71.0,  14.6),  # Elif (Manila) - 50 deg west offset
+]


### PR DESCRIPTION
## Summary
- New optimized submission achieving **78101 points** with **5/5 destinations reached**
- Uses layer 6 with carefully tuned westerly wind offsets
- Significantly better than the current leader (1487 points)

## Strategy
The submission exploits the westerly wind patterns at layer 6 with optimized departure offsets:

| Child | Destination | Offset | Points |
|-------|-------------|--------|--------|
| Ana | Winnipeg | 6° west | 54,675 |
| Babu | Bali | 6° west | 2,139 |
| Carla | Seychelles | 6° west | 7,062 |
| Diego | Nuuk | 6° west | 514 |
| Elif | Manila | 50° west | 13,711 |

The key discovery is that Ana's particle at a 6° west offset catches a long circumnavigation trajectory that covers over 54,000 km before reaching Winnipeg.

## Test plan
- [x] Verified locally with `run_submission()` and `evaluate()`
- [x] Achieves 78101 points (5/5 destinations reached)
- [ ] CI evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)