### PR TITLE
Submission: Jet Stream Rider (~25,614 points)

### DIFF
--- a/submissions/jetstream_rider.jl
+++ b/submissions/jetstream_rider.jl
@@ -1,0 +1,16 @@
+name = "Jet Stream Rider"
+description = "Riding the upper tropospheric jet"
+
+nchildren = 5       # [1, 26]
+layer = 4           # [1, 8], 1 is top layer, 8 is surface layer
+
+# Optimized departure locations using grid search
+# Layer 4 provides access to strong upper tropospheric winds (jet stream)
+# Individual offsets were optimized: Ana=2, Babu=3, Carla=3, Diego=3, Elif=3
+departures = [
+    (-99.1, 49.9),   # Ana (Winnipeg) - 2 degrees west
+    (112.0, -8.7),   # Babu (Bali) - 3 degrees west
+    (70.5, -4.6),    # Carla (Seychelles) - 3 degrees west
+    (-54.7, 64.2),   # Diego (Greenland) - 3 degrees west
+    (118.0, 14.6),   # Elif (Manila) - 3 degrees west
+]


### PR DESCRIPTION
## Summary
- New submission "Jet Stream Rider" achieving ~25,614 points
- Uses layer 4 (upper troposphere) to access strong jet stream winds
- Optimized departure positions found via grid search over layer and offset parameters
- Reaches 4/5 destinations with Diego (Greenland) contributing ~25,859 points alone

## Approach
The strategy exploits the upper tropospheric jet stream at layer 4, which provides stronger and more consistent westerly winds than lower layers. Individual departure offsets were optimized for each of the 5 target destinations:
- Ana (Winnipeg): 2 degrees west offset
- Babu (Bali): 3 degrees west offset
- Carla (Seychelles): 3 degrees west offset
- Diego (Greenland): 3 degrees west offset
- Elif (Manila): 3 degrees west offset

## Results
| Destination | Location | Status | Points |
|-------------|----------|--------|--------|
| Ana | Winnipeg | missed | -1,433 |
| Babu | Bali | reached | 375 |
| Carla | Seychelles | reached | 396 |
| Diego | Greenland | reached | 25,859 |
| Elif | Manila | reached | 417 |
| **Total** | | 4/5 reached | **25,614** |

The key insight is that Diego's particle travels an exceptionally long distance at layer 4 before reaching Greenland, capitalizing on the North Atlantic jet stream.

## Test plan
- [x] Verified locally using `run_submission()` and `evaluate()`
- [x] Submission file follows required format

---
Generated with [Claude Code](https://claude.com/claude-code)